### PR TITLE
added HAL

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,15 @@ angular.module('h-factors', [])
       name: 'HAL',
       spec:'http://stateless.co/hal_specification.html',
       mime: ['application/hal+json', 'application/hal+xml'],
-      incomplete: true
+      CL: true,
+      CR: false,
+      CU: false,
+      CM: false,
+      LE: false,
+      LO: true,
+      LT: true,
+      LN: false,
+      LI: false
     },
 
     {


### PR DESCRIPTION
I filled in the entry for HAL.  Lots of `false` values due to HAL's design minimalism!
- `CL: true`
  HAL supports meaningful link rels.
- `CR: false`
  HAL specifies nothing about control information for read operations.
- `CU: false`
  HAL specifies nothing about control information for update operations.
- `CM: false`
  HAL specifies no way to indicate protocol (HTTP) method.
- `LE: false`
  HAL does not support embedding remote objects by href.  Embedded objects are included in their entirety, and other links are just links.
- `LO: true`
  Outgoing links are supported in HAL.
- `LT: true`
  HAL supports templated GET links via [URI Templates](https://tools.ietf.org/html/rfc6570).
- `LN: false`
  There is no specified way to indicate a non-idempotent link in HAL.
- `LI: false`
  There is no way to indicate that a link performs an idempotent update in HAL.
