### PR TITLE
Add JSON API details

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   </header>
 
   <main ng:controller="Factors" class="formats">
-    <article ng:repeat="f in formats" ng:class="{'draft': f.draft, 'incomplete': f.incomplete}" class="format">
+    <article ng:repeat="f in formats" ng:class="{'draft': f.draft, 'incomplete': f.incomplete, 'living-standard': f.livingStandard}" class="format">
       <h1 class="name">
         <a ng:href="{{ f.spec }}" title="Specification" target="_blank">{{ f.name }}</a>
       </h1>

--- a/index.js
+++ b/index.js
@@ -90,7 +90,16 @@ angular.module('h-factors', [])
       name: 'JSON-API',
       spec: 'http://jsonapi.org/',
       mime: ['application/vnd.api+json'],
-      incomplete: true
+      livingStandard: true,      
+      CL: false,
+      CR: false,
+      CU: false,
+      CM: false,
+      LE: true,
+      LO: true,
+      LT: false,
+      LN: true,
+      LI: true
     },
 
     {

--- a/index.less
+++ b/index.less
@@ -3,8 +3,8 @@
    this `.less` file on the client.
  */
 
-@import url(http://fonts.googleapis.com/css?family=Roboto:100,400);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Mono:100,400);
+@import url(//fonts.googleapis.com/css?family=Roboto:100,400);
+@import url(//fonts.googleapis.com/css?family=Roboto+Mono:100,400);
 
 // Colors ----------------------------------------------------------------------
 @color_light                      : #FFFFFF;

--- a/index.less
+++ b/index.less
@@ -14,6 +14,7 @@
 @color_warning                    : #EBBD63;
 @color_attention                  : #EB6361;
 
+@color_living-standard            : #368D01;
 @color_link-support-factor        : #6C8784;
 @color_control-data-support-factor: #EB6361;
 
@@ -35,7 +36,7 @@ body {
 
 body {
   margin              : 0 auto;
-  max-width           : 74em;
+  max-width           : 78em;
   background-color    : @color_light;
   color               : @color_dark;
   font-size           : @font_base-size;
@@ -81,8 +82,8 @@ header {
   overflow            : hidden;
   margin              : @spacing_default;
   padding             : @spacing_default;
-  width               : 17em;
-  height              : 17em;
+  width               : 18em;
+  height              : 18em;
   border              : 1px solid @color_shadow;
   border-radius       : .2em;
   background-color    : #fff;
@@ -97,8 +98,8 @@ header {
 
   &.draft:after {
     position          : absolute;
-    top               : 2em;
-    right             : 2em;
+    top               : 3em;
+    right             : 3em;
     padding           : .5em 4em;
     background-color  : @color_warning;
     color             : @color_light;
@@ -106,6 +107,12 @@ header {
     text-align        : center;
     font-size         : .75em;
     transform         : translate(50%, -50%) rotate(45deg);
+  }
+
+  &.living-standard:after {
+    &:extend(.format.draft:after);
+    background-color  : @color_living-standard;
+    content           : 'Living Standard';
   }
 
   &.incomplete:before {


### PR DESCRIPTION
Hi! 

First off, thanks for making this handy reference.

This PR does three things:
1. It updates the JSON API entry to list the hypermedia features the specification currently supports.
2. It removes the "Incomplete" designation from JSON API and instead designates it as a "Living Standard". My thinking behind this "Living Standard" designation is as follows; please let me know what you think. 
   
   Basically, JSON API has reached version 1.0 and is [committed](http://jsonapi.org/faq/#what-is-the-meaning-of-json-apis-version) to never making any backwards-incompatible changes. In that sense, it's fully published, and calling it a draft or incomplete would give the impression that it's less ready for production use than it is. At the same time, though, JSON API has been designed with the intent to add more features in a backwards-compatible way over time, and it will add more hypermedia support [very soon](https://github.com/json-api/json-api/issues?q=is%3Aopen+is%3Aissue+label%3Ahypermedia). Therefore, showing it without a label, like HAL or Atom, both of which are finished specifications, would imply that current level of hypermedia support is more permanent than it really is. Basically, JSON API is very much like HTML: new features may be added, but the existing ones are set. And, since HTML calls itself a ["living standard" now](https://html.spec.whatwg.org/multipage/), I thought that would be the most appropriate label for JSON API as well.
3. It uses a protocol-relative URI to load the Roboto font files, so that they load over HTTPS without triggering browser warnings.
